### PR TITLE
Source-target electrostatics: field from one charge set at another

### DIFF
--- a/graph_longrange/features.py
+++ b/graph_longrange/features.py
@@ -15,6 +15,7 @@ from .realspace_electrostatics import RealSpaceFiniteDifferenceElectrostaticFeat
 from .slabs import (
     CorrectivePotentialBlock,
     slab_dipole_correction_node_fields,
+    slab_dipole_correction_node_fields_source_target,
     _get_total_dipole_z,
 )
 from .utils import FIELD_CONSTANT
@@ -326,6 +327,113 @@ class NonPeriodicFeatureCorrections(torch.nn.Module):
         return self.displaced_interactions(
             batch=batch,
             positions=node_positions,
+            node_fields=node_fields,
+        )
+
+    def forward_source_target(
+        self,
+        source_feats: torch.Tensor,
+        src_positions: torch.Tensor,
+        src_batch: torch.Tensor,
+        tgt_positions: torch.Tensor,
+        tgt_batch: torch.Tensor,
+        volumes: torch.Tensor,
+        pbc: torch.Tensor,
+        correction_mode: Optional[int] = None,
+        correction_node_masks: Optional[dict] = None,
+    ) -> torch.Tensor:
+        source_feats_lm = (
+            source_feats.squeeze(-2) if source_feats.dim() == 3 else source_feats
+        )
+        if correction_mode is None:
+            pbc_bool = pbc.to(dtype=torch.bool)
+            is_pbc_graph = pbc_bool.all(dim=1)
+            is_molecule_graph = (~pbc_bool).all(dim=1)
+            is_slab_graph = pbc_bool[:, 0] & pbc_bool[:, 1] & (~pbc_bool[:, 2])
+            if is_pbc_graph.all():
+                correction_mode = CORRECTION_MODE_PBC
+            elif is_molecule_graph.all():
+                correction_mode = CORRECTION_MODE_MOLECULE
+            elif is_slab_graph.all():
+                correction_mode = CORRECTION_MODE_SLAB
+            else:
+                correction_mode = CORRECTION_MODE_MIXED
+                correction_node_masks = {
+                    "is_molecule_node": torch.index_select(is_molecule_graph, 0, tgt_batch),
+                    "is_slab_node": torch.index_select(is_slab_graph, 0, tgt_batch),
+                }
+
+        if correction_mode == CORRECTION_MODE_PBC:
+            n_tgt = tgt_positions.size(0)
+            return tgt_positions.new_zeros(
+                (n_tgt, self.displaced_interactions.projections_dim)
+            )
+
+        if correction_mode == CORRECTION_MODE_MOLECULE:
+            node_fields = self.self_field.forward_source_target(
+                charge_coefficients=source_feats_lm,
+                src_positions=src_positions,
+                src_batch=src_batch,
+                tgt_positions=tgt_positions,
+                tgt_batch=tgt_batch,
+                volumes=volumes,
+            )
+            return self.displaced_interactions(
+                batch=tgt_batch,
+                positions=tgt_positions,
+                node_fields=node_fields,
+            )
+
+        if correction_mode == CORRECTION_MODE_SLAB:
+            node_fields = slab_dipole_correction_node_fields_source_target(
+                source_feats=source_feats_lm,
+                src_positions=src_positions,
+                src_batch=src_batch,
+                tgt_positions=tgt_positions,
+                tgt_batch=tgt_batch,
+                volumes=volumes,
+            )
+            return self.displaced_interactions(
+                batch=tgt_batch,
+                positions=tgt_positions,
+                node_fields=node_fields,
+            )
+
+        # MIXED — masks are over targets
+        if correction_node_masks is None:
+            pbc_bool = pbc.to(dtype=torch.bool)
+            is_molecule_graph = (~pbc_bool).all(dim=1)
+            is_slab_graph = pbc_bool[:, 0] & pbc_bool[:, 1] & (~pbc_bool[:, 2])
+            correction_node_masks = {
+                "is_molecule_node": torch.index_select(is_molecule_graph, 0, tgt_batch),
+                "is_slab_node": torch.index_select(is_slab_graph, 0, tgt_batch),
+            }
+
+        node_fields_molecule = self.self_field.forward_source_target(
+            charge_coefficients=source_feats_lm,
+            src_positions=src_positions,
+            src_batch=src_batch,
+            tgt_positions=tgt_positions,
+            tgt_batch=tgt_batch,
+            volumes=volumes,
+        )
+        node_fields_slab = slab_dipole_correction_node_fields_source_target(
+            source_feats=source_feats_lm,
+            src_positions=src_positions,
+            src_batch=src_batch,
+            tgt_positions=tgt_positions,
+            tgt_batch=tgt_batch,
+            volumes=volumes,
+        )
+        is_molecule = correction_node_masks["is_molecule_node"]
+        is_slab = correction_node_masks["is_slab_node"]
+        node_fields = torch.zeros_like(node_fields_molecule)
+        node_fields[is_molecule] = node_fields_molecule[is_molecule]
+        node_fields[is_slab] = node_fields_slab[is_slab]
+
+        return self.displaced_interactions(
+            batch=tgt_batch,
+            positions=tgt_positions,
             node_fields=node_fields,
         )
 
@@ -655,6 +763,188 @@ class GTOElectrostaticFeatures(torch.nn.Module):
             features_flat = features_flat - si_terms
         if correction_mode != CORRECTION_MODE_PBC:
             features_flat = features_flat + correction_terms
+        return features_flat
+
+    # --- source-target API ----------------------------------------------------
+    # Built for MM→QM electrostatic embedding where sources (MM) and receivers
+    # (QM) are disjoint node sets. Skips the self-interaction subtraction the
+    # symmetric path applies — colocated source/target rows are NOT supported.
+
+    def precompute_geometry_source_target(
+        self,
+        k_vectors: torch.Tensor,
+        k_norm2: torch.Tensor,
+        k_vector_batch: torch.Tensor,
+        k0_mask: torch.Tensor,
+        src_positions: torch.Tensor,
+        src_batch: torch.Tensor,
+        tgt_positions: torch.Tensor,
+        tgt_batch: torch.Tensor,
+        volume: torch.Tensor,
+        pbc: torch.Tensor,
+        force_pbc_evaluator: bool = False,
+    ) -> dict:
+        if torch.any(pbc) or force_pbc_evaluator:
+            return self._pbc_precompute_geometry_source_target(
+                k_vectors=k_vectors,
+                k_norm2=k_norm2,
+                k_vector_batch=k_vector_batch,
+                k0_mask=k0_mask,
+                src_positions=src_positions,
+                src_batch=src_batch,
+                tgt_positions=tgt_positions,
+                tgt_batch=tgt_batch,
+                volume=volume,
+                pbc=pbc,
+            )
+        return self._realspace_precompute_geometry_source_target(
+            src_positions=src_positions,
+            src_batch=src_batch,
+            tgt_positions=tgt_positions,
+            tgt_batch=tgt_batch,
+        )
+
+    def forward_source_target(
+        self, cache: dict, source_feats: torch.Tensor, pbc: torch.Tensor
+    ) -> torch.Tensor:
+        if cache.get("mode") == "realspace":
+            return self._realspace_forward_dynamic_source_target(
+                source_feats=source_feats, cache=cache
+            )
+        return self._pbc_forward_dynamic_source_target(
+            source_feats=source_feats, cache=cache
+        )
+
+    def _realspace_precompute_geometry_source_target(
+        self,
+        src_positions: torch.Tensor,
+        src_batch: torch.Tensor,
+        tgt_positions: torch.Tensor,
+        tgt_batch: torch.Tensor,
+    ) -> dict:
+        return {
+            "mode": "realspace",
+            "src_positions": src_positions,
+            "src_batch": src_batch,
+            "tgt_positions": tgt_positions,
+            "tgt_batch": tgt_batch,
+        }
+
+    def _realspace_forward_dynamic_source_target(
+        self, source_feats: torch.Tensor, cache: dict
+    ) -> torch.Tensor:
+        return self.realspace_features.forward_source_target(
+            source_feats=source_feats,
+            src_positions=cache["src_positions"],
+            src_batch=cache["src_batch"],
+            tgt_positions=cache["tgt_positions"],
+            tgt_batch=cache["tgt_batch"],
+        )
+
+    def _pbc_precompute_geometry_source_target(
+        self,
+        k_vectors: torch.Tensor,
+        k_norm2: torch.Tensor,
+        k_vector_batch: torch.Tensor,
+        k0_mask: torch.Tensor,
+        src_positions: torch.Tensor,
+        src_batch: torch.Tensor,
+        tgt_positions: torch.Tensor,
+        tgt_batch: torch.Tensor,
+        volume: torch.Tensor,
+        pbc: torch.Tensor,
+    ) -> dict:
+        inner_src = torch.matmul(k_vectors, src_positions.t())
+        mask_src = k_vector_batch[:, None] == src_batch[None, :]
+        mask_src_f = mask_src.to(dtype=inner_src.dtype)
+        cosines_src = torch.cos(inner_src) * mask_src_f
+        sines_src = torch.sin(inner_src) * mask_src_f
+
+        inner_tgt = torch.matmul(k_vectors, tgt_positions.t())
+        mask_tgt = k_vector_batch[:, None] == tgt_batch[None, :]
+        mask_tgt_f = mask_tgt.to(dtype=inner_tgt.dtype)
+        cosines_tgt = torch.cos(inner_tgt) * mask_tgt_f
+        sines_tgt = torch.sin(inner_tgt) * mask_tgt_f
+
+        density_basis_fs = self.density_basis(k_vectors, k_norm2, k0_mask)
+        feature_basis_fs = self.feature_basis(k_vectors, k_norm2, k0_mask)
+
+        volume_per_k = volume.reshape(-1)[k_vector_batch]
+        k0_mask_bool = k0_mask > 0.0
+        k_factor_coulomb = torch.zeros_like(k_norm2)
+        k_factor_coulomb[~k0_mask_bool] = 1.0 / k_norm2[~k0_mask_bool]
+        k_factor_proj = torch.ones_like(k_norm2)
+        k_factor_proj[k0_mask_bool] = 0.5
+
+        # Correction mode is determined per-target-graph (the mask we apply at
+        # the end is over target rows).
+        correction_cache = self._build_correction_cache(pbc=pbc, batch=tgt_batch)
+
+        return {
+            "mode": "pbc",
+            "k_vectors": k_vectors,
+            "k_norm2": k_norm2,
+            "k_vector_batch": k_vector_batch,
+            "k0_mask": k0_mask,
+            "volume_per_k": volume_per_k,
+            "k_factor_coulomb": k_factor_coulomb,
+            "k_factor_proj": k_factor_proj,
+            "volumes": volume.reshape(-1),
+            "src_positions": src_positions,
+            "src_batch": src_batch,
+            "tgt_positions": tgt_positions,
+            "tgt_batch": tgt_batch,
+            "pbc": pbc,
+            "cosines_src": cosines_src,
+            "sines_src": sines_src,
+            "cosines_tgt": cosines_tgt,
+            "sines_tgt": sines_tgt,
+            "density_basis_fs": density_basis_fs,
+            "feature_basis_fs": feature_basis_fs,
+            **correction_cache,
+        }
+
+    def _pbc_forward_dynamic_source_target(
+        self, source_feats: torch.Tensor, cache: dict
+    ) -> torch.Tensor:
+        density = assemble_fourier_series_batch(
+            source_feats=source_feats,
+            cosines=cache["cosines_src"],
+            sines=cache["sines_src"],
+            density_basis_fs=cache["density_basis_fs"],
+            volume_per_k=cache["volume_per_k"],
+        )
+        potential = apply_coulomb_kernel_batch(
+            k_norm2=cache["k_norm2"],
+            density=density,
+            k_factor_coulomb=cache["k_factor_coulomb"],
+        )
+        features_si = project_to_features_batch(
+            potential=potential,
+            feature_basis_fs=cache["feature_basis_fs"],
+            cosines=cache["cosines_tgt"],
+            sines=cache["sines_tgt"],
+            k_factor_proj=cache["k_factor_proj"],
+        )
+        features_flat = features_si.reshape(features_si.size(0), -1)
+        features_flat = self._permute_output_channels(features_flat)
+
+        correction_mode = cache.get("correction_mode", CORRECTION_MODE_MIXED)
+        if correction_mode != CORRECTION_MODE_PBC:
+            correction_terms = self.non_periodic_correction_terms.forward_source_target(
+                source_feats=source_feats,
+                src_positions=cache["src_positions"],
+                src_batch=cache["src_batch"],
+                tgt_positions=cache["tgt_positions"],
+                tgt_batch=cache["tgt_batch"],
+                volumes=cache["volumes"],
+                pbc=cache["pbc"],
+                correction_mode=correction_mode,
+                correction_node_masks=cache.get("correction_node_masks"),
+            )
+            features_flat = features_flat + correction_terms
+
+        # No self-interaction subtraction: sources and targets are disjoint.
         return features_flat
 
 

--- a/graph_longrange/features.py
+++ b/graph_longrange/features.py
@@ -5,6 +5,7 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+import math
 from typing import List, Optional
 
 import torch
@@ -926,7 +927,11 @@ class GTOElectrostaticFeatures(torch.nn.Module):
             sines=cache["sines_tgt"],
             k_factor_proj=cache["k_factor_proj"],
         )
-        features_flat = features_si.reshape(features_si.size(0), -1)
+        # State the trailing dimension rather than inferring it with -1: with zero
+        # targets the tensor holds no elements and -1 cannot be resolved.
+        features_flat = features_si.reshape(
+            features_si.size(0), math.prod(features_si.shape[1:])
+        )
         features_flat = self._permute_output_channels(features_flat)
 
         correction_mode = cache.get("correction_mode", CORRECTION_MODE_MIXED)

--- a/graph_longrange/gto_utils.py
+++ b/graph_longrange/gto_utils.py
@@ -350,6 +350,8 @@ class DisplacedGTOExternalFieldBlock(torch.nn.Module):
         # field contains [V, E_x, E_y, E_z]
         assert field.dim() == 2
 
+        # ensure the convention is the same for now
+        # clarify whether we need external potential in the future
         if per_atom:
             # Field already evaluated at each atom position; no gauge transform.
             node_fields = field.clone()

--- a/graph_longrange/gto_utils.py
+++ b/graph_longrange/gto_utils.py
@@ -344,19 +344,24 @@ class DisplacedGTOExternalFieldBlock(torch.nn.Module):
         self,
         batch,  # [n_node]
         positions,
-        field,  # [n_graph, 4]
+        field,  # [n_graph, 4] normally; [n_node, 4] when per_atom=True
+        per_atom: bool = False,
     ):
         # field contains [V, E_x, E_y, E_z]
         assert field.dim() == 2
 
-        node_fields = torch.index_select(field, 0, batch)  # [n_nodes, 4]
-        potential = node_fields[:, 0].clone()
+        if per_atom:
+            # Field already evaluated at each atom position; no gauge transform.
+            node_fields = field.clone()
+        else:
+            node_fields = torch.index_select(field, 0, batch)  # [n_nodes, 4]
+            # Gauge transform: V_node = V_graph + E . r_node
+            potential_from_displacement = torch.einsum(
+                "bi,bi->b", positions, node_fields[:, 1:].clone()
+            )
+            node_fields[:, 0] = node_fields[:, 0] + potential_from_displacement
 
-        potential_from_displacement = torch.einsum(
-            "bi,bi->b", positions, node_fields[:, 1:].clone()
-        )
-        node_fields[:, 0] += potential_from_displacement
-
+        # Reorder [V, Ex, Ey, Ez] → [V, Ez, Ex, Ey] (e3nn convention)
         node_fields = node_fields[:, [0, 3, 1, 2]]
         projections = torch.einsum("pf,nf->np", self.matrix, node_fields)
 

--- a/graph_longrange/realspace_electrostatics.py
+++ b/graph_longrange/realspace_electrostatics.py
@@ -10,6 +10,48 @@ from .gto_utils import (
 )
 
 @torch.no_grad()
+def batch_bipartite_pairs(
+    src_batch: torch.Tensor, tgt_batch: torch.Tensor
+) -> torch.Tensor:
+    """Build all (sender, receiver) edges with src_batch[s] == tgt_batch[t].
+
+    Sources and targets live in disjoint node sets, so no self-exclusion is
+    needed. Edge order is per-graph, then row-major (sender-major) within each
+    graph — this matches the order produced by the symmetric primitive when
+    restricted to MM→QM pairs, which keeps scatter sums bit-equivalent to the
+    legacy concat path under zero-coefficient padding.
+
+    Args:
+        src_batch: [N_src] graph ID per source node.
+        tgt_batch: [N_tgt] graph ID per target node.
+
+    Returns:
+        edge_index: [2, E] — row 0 = source index, row 1 = target index.
+    """
+    src_batch = src_batch.long()
+    tgt_batch = tgt_batch.long()
+    if src_batch.numel() == 0 or tgt_batch.numel() == 0:
+        return torch.empty((2, 0), dtype=torch.long, device=src_batch.device)
+
+    G = int(max(int(src_batch.max().item()), int(tgt_batch.max().item()))) + 1
+    edges = []
+    for g in range(G):
+        s_nodes = (src_batch == g).nonzero(as_tuple=False).view(-1)
+        t_nodes = (tgt_batch == g).nonzero(as_tuple=False).view(-1)
+        if s_nodes.numel() == 0 or t_nodes.numel() == 0:
+            continue
+        Ds = s_nodes.size(0)
+        Dt = t_nodes.size(0)
+        row = s_nodes.view(-1, 1).expand(-1, Dt).reshape(-1)
+        col = t_nodes.view(1, -1).expand(Ds, -1).reshape(-1)
+        edges.append(torch.stack([row, col], dim=0))
+
+    if not edges:
+        return torch.empty((2, 0), dtype=torch.long, device=src_batch.device)
+    return torch.cat(edges, dim=1)
+
+
+@torch.no_grad()
 def batch_complete_graph_excluding_self_duplicates_vector(
     batch: torch.Tensor, N: int
 ) -> torch.Tensor:
@@ -238,6 +280,29 @@ def charges_features_from_graph(
     return features
 
 
+def charges_features_from_bipartite_graph(
+    charges,                # [N_src]
+    src_positions,          # [N_src, 3]
+    tgt_positions,          # [N_tgt, 3]
+    edge_index,             # [2, E] — row 0 in src space, row 1 in tgt space
+    n_targets,
+    total_width_factors,    # [1, n_radial]
+):
+    """Bipartite analogue of charges_features_from_graph for MM→QM fields."""
+    sender, receiver = edge_index
+    R_ij = src_positions[sender] - tgt_positions[receiver]
+    d_ij = torch.norm(R_ij, dim=-1, keepdim=True)
+    smooth_reciprocal = torch.erf(0.5 * d_ij / total_width_factors) / (d_ij + 1e-6)
+    features = scatter_sum(
+        charges[sender].unsqueeze(-1) * smooth_reciprocal,
+        receiver,
+        dim=0,
+        dim_size=n_targets,
+    )
+    features = FIELD_CONSTANT * features / (4 * pi)
+    return features
+
+
 class RealSpaceFiniteDifferenceElectrostaticFeatures(torch.nn.Module):
     """Computes field features for L=0,1 charges and features.
     vector charges and features are represented by displaced scalars."""
@@ -416,3 +481,123 @@ class RealSpaceFiniteDifferenceElectrostaticFeatures(torch.nn.Module):
             features += self_interaction_terms
 
         return features, self_interaction_terms, None
+
+    def call_st_density_0_feats_0(
+        self,
+        source_feats: torch.Tensor,   # [N_src, m_dim]
+        src_positions: torch.Tensor,
+        src_batch: torch.Tensor,
+        tgt_positions: torch.Tensor,
+        tgt_batch: torch.Tensor,
+    ) -> torch.Tensor:
+        edge_index = batch_bipartite_pairs(src_batch, tgt_batch)
+        feats = charges_features_from_bipartite_graph(
+            charges=source_feats[:, 0],
+            src_positions=src_positions,
+            tgt_positions=tgt_positions,
+            edge_index=edge_index,
+            n_targets=tgt_positions.shape[0],
+            total_width_factors=self.total_width_factors.unsqueeze(0),
+        )
+        return self.l0_factors * feats
+
+    def call_st_density_1_feats_1(
+        self,
+        source_feats: torch.Tensor,   # [N_src, m_dim]
+        src_positions: torch.Tensor,
+        src_batch: torch.Tensor,
+        tgt_positions: torch.Tensor,
+        tgt_batch: torch.Tensor,
+    ) -> torch.Tensor:
+        # Source 4× duplication encodes source dipoles as displaced charges.
+        ext_src_positions = src_positions.repeat_interleave(4, dim=0)
+        ext_src_positions[1::4] += self.x
+        ext_src_positions[2::4] += self.y
+        ext_src_positions[3::4] += self.z
+        ext_src_batch = src_batch.repeat_interleave(4)
+        src_charges = torch.zeros_like(ext_src_positions[:, 0])
+        src_charges[1::4] = source_feats[:, 3] / self.offset
+        src_charges[2::4] = source_feats[:, 1] / self.offset
+        src_charges[3::4] = source_feats[:, 2] / self.offset
+        src_charges[0::4] = source_feats[:, 0] - (
+            src_charges[1::4] + src_charges[2::4] + src_charges[3::4]
+        )
+
+        # Target 4× duplication encodes the receive-side l=1 finite-difference basis.
+        ext_tgt_positions = tgt_positions.repeat_interleave(4, dim=0)
+        ext_tgt_positions[1::4] += self.x
+        ext_tgt_positions[2::4] += self.y
+        ext_tgt_positions[3::4] += self.z
+        ext_tgt_batch = tgt_batch.repeat_interleave(4)
+
+        edge_index = batch_bipartite_pairs(ext_src_batch, ext_tgt_batch)
+        scalar_features = charges_features_from_bipartite_graph(
+            charges=src_charges,
+            src_positions=ext_src_positions,
+            tgt_positions=ext_tgt_positions,
+            edge_index=edge_index,
+            n_targets=ext_tgt_positions.shape[0],
+            total_width_factors=self.total_width_factors.unsqueeze(0),
+        )
+
+        n_tgt = tgt_positions.shape[0]
+        all_features = torch.zeros(
+            n_tgt,
+            4 * self.num_radial,
+            dtype=torch.get_default_dtype(),
+            device=tgt_positions.device,
+        )
+        all_features[:, : self.num_radial] = self.l0_factors * scalar_features[0::4]
+        all_features[:, self.num_radial :: 3] = self.l1_factors * (
+            scalar_features[2::4] - scalar_features[0::4]
+        )
+        all_features[:, self.num_radial + 1 :: 3] = self.l1_factors * (
+            scalar_features[3::4] - scalar_features[0::4]
+        )
+        all_features[:, self.num_radial + 2 :: 3] = self.l1_factors * (
+            scalar_features[1::4] - scalar_features[0::4]
+        )
+        return all_features
+
+    def forward_source_target(
+        self,
+        source_feats: torch.Tensor,    # [N_src, 1, m_dim] or [N_src, m_dim]
+        src_positions: torch.Tensor,
+        src_batch: torch.Tensor,
+        tgt_positions: torch.Tensor,
+        tgt_batch: torch.Tensor,
+    ) -> torch.Tensor:
+        """Source–target field features at tgt_positions from sources at src_positions.
+
+        Precondition: source and target node sets are disjoint. The block does
+        not subtract a self-interaction term, so colocated source/target rows
+        will produce wrong answers. Documented; not enforced (O(N²) check).
+        """
+        if source_feats.dim() == 3:
+            source_feats_2d = source_feats.squeeze(-2)
+        else:
+            source_feats_2d = source_feats
+
+        if self.density_max_l == 0 and self.projection_max_l == 0:
+            return self.call_st_density_0_feats_0(
+                source_feats_2d, src_positions, src_batch, tgt_positions, tgt_batch
+            )
+        if self.density_max_l == 1 and self.projection_max_l == 0:
+            all_feats = self.call_st_density_1_feats_1(
+                source_feats_2d, src_positions, src_batch, tgt_positions, tgt_batch
+            )
+            return all_feats[:, : self.num_radial]
+        if self.density_max_l == 0 and self.projection_max_l == 1:
+            padded = torch.zeros(
+                source_feats_2d.shape[0],
+                4,
+                dtype=source_feats_2d.dtype,
+                device=source_feats_2d.device,
+            )
+            padded[:, 0] = source_feats_2d[:, 0]
+            return self.call_st_density_1_feats_1(
+                padded, src_positions, src_batch, tgt_positions, tgt_batch
+            )
+        return self.call_st_density_1_feats_1(
+            source_feats_2d, src_positions, src_batch, tgt_positions, tgt_batch
+        )

--- a/graph_longrange/slabs.py
+++ b/graph_longrange/slabs.py
@@ -1,5 +1,6 @@
 # specifically for electrocatalysis, certain charge compensation schemes and dipole corrections are needed
-import torch 
+import torch
+from typing import Optional
 from mace.tools.scatter import scatter_sum, scatter_mean
 from scipy.constants import pi
 from .utils import FIELD_CONSTANT, CUBIC_MADELUNG
@@ -36,10 +37,21 @@ def _is_batch1(batch: torch.Tensor) -> bool:
 
 
 def _get_total_dipole_z(
-    source_feats: torch.Tensor, node_positions: torch.Tensor, batch: torch.Tensor
+    source_feats: torch.Tensor,
+    node_positions: torch.Tensor,
+    batch: torch.Tensor,
+    n_graphs: Optional[int] = None,
 ) -> torch.Tensor:
+    """Per-graph total z-dipole of the given charges.
+
+    ``n_graphs`` has to be supplied whenever ``batch`` may not reach every graph.
+    That is the ordinary situation in the source-target setting, where a graph
+    can hold targets but no sources and the result still needs a (zero) row for
+    it.  Left as ``None`` the count is inferred from ``batch``, which is correct
+    when the sources cover every graph, as they always do when source == target.
+    """
     charges = source_feats[:, 0]
-    if _is_batch1(batch):
+    if _is_batch1(batch) and (n_graphs is None or n_graphs == 1):
         total_dipole_z = (node_positions[:, 2] * charges).sum().unsqueeze(0)
         if source_feats.shape[-1] > 1:
             local_dipoles = source_feats[:, 1:4]
@@ -47,11 +59,13 @@ def _get_total_dipole_z(
         return total_dipole_z
 
     total_dipole_z = scatter_sum(
-        src=node_positions[:, 2] * charges, index=batch, dim=0
+        src=node_positions[:, 2] * charges, index=batch, dim=0, dim_size=n_graphs
     )
     if source_feats.shape[-1] > 1:
         local_dipoles = source_feats[:, 1:4]
-        total_dipole_p = scatter_sum(src=local_dipoles, index=batch, dim=0)
+        total_dipole_p = scatter_sum(
+            src=local_dipoles, index=batch, dim=0, dim_size=n_graphs
+        )
         total_dipole_z = total_dipole_z + total_dipole_p[:, 1]
     return total_dipole_z
 
@@ -111,7 +125,9 @@ def slab_dipole_correction_node_fields_source_target(
     volumes: torch.Tensor,
 ):
     """Slab dipole correction: per-graph z-dipole from sources, field at targets."""
-    total_dipole_z = _get_total_dipole_z(source_feats, src_positions, src_batch)
+    total_dipole_z = _get_total_dipole_z(
+        source_feats, src_positions, src_batch, n_graphs=volumes.shape[0]
+    )
     A = FIELD_CONSTANT / (4 * pi)
     total_field_z = A * 4 * pi * total_dipole_z / volumes
     spread_total_field_z = torch.index_select(total_field_z, 0, tgt_batch)
@@ -222,20 +238,33 @@ class CorrectivePotentialBlock(torch.nn.Module):
         avoids the wasteful concat-and-slice pattern in MM→QM embedding.
         """
         # SOURCE side: per-graph (charge, dipole, quadrupole) from charge_coefficients.
-        total_charge = scatter_sum(src=charge_coefficients[:, 0], index=src_batch, dim=-1)
+        # Every reduction is sized by the number of graphs rather than by the
+        # highest index present in src_batch: a graph may hold targets but no
+        # sources, and it still needs a (zero) row so the target-side
+        # index_select below can address it.
+        n_graphs = volumes.shape[0]
+        total_charge = scatter_sum(
+            src=charge_coefficients[:, 0], index=src_batch, dim=-1, dim_size=n_graphs
+        )
         q_r_src = src_positions * charge_coefficients[:, 0].unsqueeze(-1)
-        total_dipole = scatter_sum(src=q_r_src, index=src_batch, dim=0)
+        total_dipole = scatter_sum(
+            src=q_r_src, index=src_batch, dim=0, dim_size=n_graphs
+        )
         r_squared_src = torch.sum(torch.square(src_positions), dim=-1)
         q_rr = r_squared_src * charge_coefficients[:, 0]
-        quadrupole = scatter_sum(src=q_rr, index=src_batch, dim=0)
+        quadrupole = scatter_sum(
+            src=q_rr, index=src_batch, dim=0, dim_size=n_graphs
+        )
 
         if self.density_max_l > 0:
             local_dipoles_cartesian = charge_coefficients[..., [3, 1, 2]]
             total_dipole = total_dipole + scatter_sum(
-                src=local_dipoles_cartesian, index=src_batch, dim=-2
+                src=local_dipoles_cartesian, index=src_batch, dim=-2, dim_size=n_graphs
             )
             p_dot_r = torch.einsum("bi,bi->b", src_positions, local_dipoles_cartesian)
-            quadrupole = quadrupole + 2 * scatter_sum(src=p_dot_r, index=src_batch, dim=0)
+            quadrupole = quadrupole + 2 * scatter_sum(
+                src=p_dot_r, index=src_batch, dim=0, dim_size=n_graphs
+            )
 
         # TARGET side: spread per-graph quantities to tgt_batch and evaluate field at tgt_positions.
         spread_dipoles = torch.index_select(total_dipole, 0, tgt_batch)

--- a/graph_longrange/slabs.py
+++ b/graph_longrange/slabs.py
@@ -102,6 +102,31 @@ def slab_dipole_correction_node_fields(
     return node_fields
 
 
+def slab_dipole_correction_node_fields_source_target(
+    source_feats: torch.Tensor,
+    src_positions: torch.Tensor,
+    src_batch: torch.Tensor,
+    tgt_positions: torch.Tensor,
+    tgt_batch: torch.Tensor,
+    volumes: torch.Tensor,
+):
+    """Slab dipole correction: per-graph z-dipole from sources, field at targets."""
+    total_dipole_z = _get_total_dipole_z(source_feats, src_positions, src_batch)
+    A = FIELD_CONSTANT / (4 * pi)
+    total_field_z = A * 4 * pi * total_dipole_z / volumes
+    spread_total_field_z = torch.index_select(total_field_z, 0, tgt_batch)
+
+    delta_V_nodes = spread_total_field_z * tgt_positions[:, 2]
+    node_fields = torch.zeros(
+        (tgt_positions.shape[0], 4),
+        dtype=tgt_positions.dtype,
+        device=tgt_positions.device,
+    )
+    node_fields[:, 0] = delta_V_nodes
+    node_fields[:, 3] = spread_total_field_z
+    return node_fields
+
+
 class CorrectivePotentialBlock(torch.nn.Module):
     """Implements the point charge corrective potential from
     https://journals.aps.org/prb/pdf/10.1103/PhysRevB.77.115139"""
@@ -174,6 +199,81 @@ class CorrectivePotentialBlock(torch.nn.Module):
 
         # L=1 piece
         quantity_a = spread_dipoles - spread_total_charge.unsqueeze(-1) * positions
+        node_fields[:, 1:] = (
+            4 * pi * self.const * quantity_a / (3 * spread_volumes.unsqueeze(-1))
+        )
+
+        return node_fields
+
+    def forward_source_target(
+        self,
+        charge_coefficients,
+        src_positions,
+        src_batch,
+        tgt_positions,
+        tgt_batch,
+        volumes,
+    ):
+        """Source-target form of forward(): per-graph multipoles from sources,
+        corrective field evaluated at target positions.
+
+        Bit-equivalent to forward() when src_positions/src_batch == positions/batch
+        and tgt_positions/tgt_batch are the same. Splitting the sum/eval stages
+        avoids the wasteful concat-and-slice pattern in MM→QM embedding.
+        """
+        # SOURCE side: per-graph (charge, dipole, quadrupole) from charge_coefficients.
+        total_charge = scatter_sum(src=charge_coefficients[:, 0], index=src_batch, dim=-1)
+        q_r_src = src_positions * charge_coefficients[:, 0].unsqueeze(-1)
+        total_dipole = scatter_sum(src=q_r_src, index=src_batch, dim=0)
+        r_squared_src = torch.sum(torch.square(src_positions), dim=-1)
+        q_rr = r_squared_src * charge_coefficients[:, 0]
+        quadrupole = scatter_sum(src=q_rr, index=src_batch, dim=0)
+
+        if self.density_max_l > 0:
+            local_dipoles_cartesian = charge_coefficients[..., [3, 1, 2]]
+            total_dipole = total_dipole + scatter_sum(
+                src=local_dipoles_cartesian, index=src_batch, dim=-2
+            )
+            p_dot_r = torch.einsum("bi,bi->b", src_positions, local_dipoles_cartesian)
+            quadrupole = quadrupole + 2 * scatter_sum(src=p_dot_r, index=src_batch, dim=0)
+
+        # TARGET side: spread per-graph quantities to tgt_batch and evaluate field at tgt_positions.
+        spread_dipoles = torch.index_select(total_dipole, 0, tgt_batch)
+        spread_total_charge = torch.index_select(total_charge, 0, tgt_batch)
+        spread_volumes = torch.index_select(volumes, 0, tgt_batch)
+        spread_total_quadrupole = torch.index_select(quadrupole, 0, tgt_batch)
+        r_squared_tgt = torch.sum(torch.square(tgt_positions), dim=-1)
+
+        node_fields = torch.zeros(
+            (tgt_positions.shape[0], 4),
+            dtype=torch.get_default_dtype(),
+            device=tgt_positions.device,
+        )
+
+        Ls = torch.pow(volumes, 0.333333)
+        delta_V_0 = CUBIC_MADELUNG * self.const * total_charge / Ls
+        node_delta_V = torch.index_select(delta_V_0, 0, tgt_batch)
+        node_delta_V += (
+            -self.const
+            * 2
+            * pi
+            * spread_total_charge
+            * r_squared_tgt
+            / (3 * spread_volumes)
+        )
+        node_delta_V += (
+            self.const
+            * 4
+            * pi
+            * torch.einsum("bi,bi->b", spread_dipoles, tgt_positions)
+            / (3 * spread_volumes)
+        )
+        node_delta_V += (
+            -self.const * 2 * pi * spread_total_quadrupole / (3 * spread_volumes)
+        )
+        node_fields[:, 0] = node_delta_V
+
+        quantity_a = spread_dipoles - spread_total_charge.unsqueeze(-1) * tgt_positions
         node_fields[:, 1:] = (
             4 * pi * self.const * quantity_a / (3 * spread_volumes.unsqueeze(-1))
         )

--- a/tests/test_features_source_target.py
+++ b/tests/test_features_source_target.py
@@ -410,3 +410,66 @@ def test_pbc_gradients_match_concat_path():
     new.sum().backward()
     torch.testing.assert_close(src_positions_b.grad, grad_src_legacy, rtol=1e-10, atol=1e-12)
     torch.testing.assert_close(tgt_positions_b.grad, grad_tgt_legacy, rtol=1e-10, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Graphs holding targets but no sources.
+#
+# Splitting the source and target sets breaks an invariant the symmetric path
+# could rely on: there, every graph with a target necessarily had a source, so
+# sizing a per-graph reduction by the highest index present in `batch` was
+# always right. Here a graph can hold targets and no sources at all, and the
+# reductions must still produce a (zero) row for it.
+# ---------------------------------------------------------------------------
+
+
+def test_slab_correction_no_leak_into_sourceless_graph():
+    """A target in a graph with no sources must feel no slab correction.
+
+    Sizing the dipole by `src_batch` alone yields one row for a two-graph batch,
+    which then broadcasts graph 0's dipole onto graph 1 — silently, with no error.
+    """
+    from graph_longrange.slabs import slab_dipole_correction_node_fields_source_target
+
+    node_fields = slab_dipole_correction_node_fields_source_target(
+        source_feats=torch.tensor([[3.0]]),
+        src_positions=torch.tensor([[0.0, 0.0, 2.0]]),
+        src_batch=torch.tensor([0]),          # every source in graph 0
+        tgt_positions=torch.tensor([[0.0, 0.0, 4.0]]),
+        tgt_batch=torch.tensor([1]),          # the target is in graph 1
+        volumes=torch.tensor([10.0, 20.0]),
+    )
+    torch.testing.assert_close(node_fields, torch.zeros_like(node_fields))
+
+
+def test_corrective_potential_handles_sourceless_trailing_graph():
+    """The highest-indexed graph having no sources must not raise."""
+    from graph_longrange.slabs import CorrectivePotentialBlock
+
+    block = CorrectivePotentialBlock(density_max_l=0)
+    node_fields = block.forward_source_target(
+        charge_coefficients=torch.tensor([[3.0]]),
+        src_positions=torch.tensor([[0.0, 0.0, 2.0]]),
+        src_batch=torch.tensor([0]),
+        tgt_positions=torch.tensor([[0.0, 0.0, 4.0], [0.0, 0.0, 5.0]]),
+        tgt_batch=torch.tensor([0, 1]),       # graph 1 has targets, no sources
+        volumes=torch.tensor([10.0, 20.0]),
+    )
+    assert node_fields.shape == (2, 4)
+    assert torch.isfinite(node_fields).all()
+
+
+def test_corrective_potential_with_no_sources_at_all():
+    """Zero sources is a legitimate input and must give a zero correction."""
+    from graph_longrange.slabs import CorrectivePotentialBlock
+
+    block = CorrectivePotentialBlock(density_max_l=0)
+    node_fields = block.forward_source_target(
+        charge_coefficients=torch.zeros((0, 1)),
+        src_positions=torch.zeros((0, 3)),
+        src_batch=torch.zeros(0, dtype=torch.long),
+        tgt_positions=torch.tensor([[0.0, 0.0, 4.0], [0.0, 0.0, 5.0]]),
+        tgt_batch=torch.tensor([0, 1]),
+        volumes=torch.tensor([10.0, 20.0]),
+    )
+    torch.testing.assert_close(node_fields, torch.zeros_like(node_fields))

--- a/tests/test_features_source_target.py
+++ b/tests/test_features_source_target.py
@@ -473,3 +473,39 @@ def test_corrective_potential_with_no_sources_at_all():
         volumes=torch.tensor([10.0, 20.0]),
     )
     torch.testing.assert_close(node_fields, torch.zeros_like(node_fields))
+
+
+def test_kspace_zero_targets_returns_empty_features():
+    """No targets is a legitimate input and must give an empty feature tensor.
+
+    The k-space path flattens with reshape, and inferring the trailing dimension
+    with -1 cannot work when the tensor has no elements to infer from.
+    """
+    _set_dtype()
+    torch.manual_seed(0)
+
+    kspace_cutoff = 4.0
+    descriptor = _build_descriptor(
+        density_max_l=0,
+        feature_max_l=0,
+        feature_widths=[0.8, 1.6],
+        kspace_cutoff=kspace_cutoff,
+    )
+
+    n_src = 4
+    src_positions = torch.randn(n_src, 3) * 2.0
+    src_batch = torch.zeros(n_src, dtype=torch.long)
+    src_feats = torch.randn(n_src, 1)
+    tgt_positions = torch.zeros((0, 3))
+    tgt_batch = torch.zeros(0, dtype=torch.long)
+
+    cell, rcell, volume, pbc = _make_pbc_geometry()
+    k_vectors, k_norm2, k_vector_batch, k0_mask = compute_k_vectors_flat(
+        kspace_cutoff, cell, rcell
+    )
+
+    features = _new_source_target(
+        descriptor, k_vectors, k_norm2, k_vector_batch, k0_mask,
+        src_positions, src_batch, src_feats, tgt_positions, tgt_batch, volume, pbc,
+    )
+    assert features.shape[0] == 0

--- a/tests/test_features_source_target.py
+++ b/tests/test_features_source_target.py
@@ -1,0 +1,342 @@
+"""Equivalence tests for the source-target descriptor API.
+
+The new `forward_source_target` path on `GTOElectrostaticFeatures` (and the
+underlying `RealSpaceFiniteDifferenceElectrostaticFeatures`,
+`NonPeriodicFeatureCorrections`, `CorrectivePotentialBlock`,
+`slab_dipole_correction_node_fields_source_target`) must produce the same
+field features at target nodes as the legacy concat-and-slice approach when
+the QM (target-only) source coefficients are zero — that is, the case
+exercised by `_compute_mm_field_features` in `mace/mace/modules/extensions.py`.
+
+Adding zero rows to a batched matmul / scatter is exact in IEEE float, so
+equivalence is expected at float64 round-off (allclose @ 1e-12).
+"""
+from __future__ import annotations
+
+# PyTorch 2.6 changed torch.load default to weights_only=True; e3nn's
+# constants.pt uses `slice` which is not in the default allowlist. Patch.
+import torch
+torch.serialization.add_safe_globals([slice])
+
+import pytest
+
+from graph_longrange.features import GTOElectrostaticFeatures
+from graph_longrange.kspace import compute_k_vectors_flat
+
+
+# ---------------------------------------------------------------------------
+# Reference impl: legacy concat-and-slice path (mirrors _compute_mm_field_features)
+# ---------------------------------------------------------------------------
+
+def _legacy_concat_and_slice(
+    descriptor: GTOElectrostaticFeatures,
+    k_vectors,
+    k_norm2,
+    k_vector_batch,
+    k0_mask,
+    src_positions,
+    src_batch,
+    src_feats,                          # [N_src, m_dim]
+    tgt_positions,
+    tgt_batch,
+    volume,
+    pbc,
+    force_pbc_evaluator: bool = False,
+):
+    n_src = src_positions.shape[0]
+    m_dim = src_feats.shape[-1]
+    tgt_zeros = torch.zeros(
+        tgt_positions.shape[0], m_dim, dtype=src_feats.dtype, device=src_feats.device
+    )
+    all_positions = torch.cat([src_positions, tgt_positions], dim=0)
+    all_batch = torch.cat([src_batch, tgt_batch], dim=0)
+    all_feats = torch.cat([src_feats, tgt_zeros], dim=0)
+
+    cache = descriptor.precompute_geometry(
+        k_vectors=k_vectors,
+        k_norm2=k_norm2,
+        k_vector_batch=k_vector_batch,
+        k0_mask=k0_mask,
+        node_positions=all_positions,
+        batch=all_batch,
+        volume=volume,
+        pbc=pbc,
+        force_pbc_evaluator=force_pbc_evaluator,
+    )
+    feats_full = descriptor.forward_dynamic(
+        cache=cache, source_feats=all_feats.unsqueeze(-2), pbc=pbc
+    )
+    return feats_full[n_src:]
+
+
+def _new_source_target(
+    descriptor: GTOElectrostaticFeatures,
+    k_vectors,
+    k_norm2,
+    k_vector_batch,
+    k0_mask,
+    src_positions,
+    src_batch,
+    src_feats,
+    tgt_positions,
+    tgt_batch,
+    volume,
+    pbc,
+    force_pbc_evaluator: bool = False,
+):
+    cache = descriptor.precompute_geometry_source_target(
+        k_vectors=k_vectors,
+        k_norm2=k_norm2,
+        k_vector_batch=k_vector_batch,
+        k0_mask=k0_mask,
+        src_positions=src_positions,
+        src_batch=src_batch,
+        tgt_positions=tgt_positions,
+        tgt_batch=tgt_batch,
+        volume=volume,
+        pbc=pbc,
+        force_pbc_evaluator=force_pbc_evaluator,
+    )
+    return descriptor.forward_source_target(
+        cache=cache, source_feats=src_feats.unsqueeze(-2), pbc=pbc
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _set_dtype():
+    torch.set_default_dtype(torch.float64)
+
+
+def _make_pbc_geometry(box: float = 8.0):
+    cell = torch.eye(3).unsqueeze(0) * box
+    rcell = torch.inverse(cell)
+    volume = torch.det(cell)
+    pbc = torch.tensor([[True, True, True]], dtype=torch.bool)
+    return cell, rcell, volume, pbc
+
+
+def _make_nonpbc_geometry(box: float = 30.0):
+    # Use a large pseudo-cell for the molecule-correction code path.
+    cell = torch.eye(3).unsqueeze(0) * box
+    rcell = torch.inverse(cell)
+    volume = torch.det(cell)
+    pbc = torch.tensor([[False, False, False]], dtype=torch.bool)
+    return cell, rcell, volume, pbc
+
+
+def _build_descriptor(density_max_l, feature_max_l, feature_widths, kspace_cutoff):
+    return GTOElectrostaticFeatures(
+        density_max_l=density_max_l,
+        density_smearing_width=1.0,
+        feature_max_l=feature_max_l,
+        feature_smearing_widths=feature_widths,
+        kspace_cutoff=kspace_cutoff,
+        include_self_interaction=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PBC equivalence
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("density_max_l,feature_max_l", [(0, 0), (0, 1), (1, 0), (1, 1)])
+def test_pbc_equivalence_single_graph(density_max_l, feature_max_l):
+    _set_dtype()
+    torch.manual_seed(0)
+
+    kspace_cutoff = 4.0
+    descriptor = _build_descriptor(
+        density_max_l=density_max_l,
+        feature_max_l=feature_max_l,
+        feature_widths=[0.8, 1.6],
+        kspace_cutoff=kspace_cutoff,
+    )
+
+    n_src, n_tgt = 6, 4
+    src_positions = torch.randn(n_src, 3) * 2.0
+    tgt_positions = torch.randn(n_tgt, 3) * 2.0 + 0.5
+    src_batch = torch.zeros(n_src, dtype=torch.long)
+    tgt_batch = torch.zeros(n_tgt, dtype=torch.long)
+    m_dim = (density_max_l + 1) ** 2
+    src_feats = torch.randn(n_src, m_dim)
+
+    cell, rcell, volume, pbc = _make_pbc_geometry()
+    k_vectors, k_norm2, k_vector_batch, k0_mask = compute_k_vectors_flat(
+        kspace_cutoff, cell, rcell
+    )
+
+    legacy = _legacy_concat_and_slice(
+        descriptor, k_vectors, k_norm2, k_vector_batch, k0_mask,
+        src_positions, src_batch, src_feats, tgt_positions, tgt_batch, volume, pbc,
+    )
+    new = _new_source_target(
+        descriptor, k_vectors, k_norm2, k_vector_batch, k0_mask,
+        src_positions, src_batch, src_feats, tgt_positions, tgt_batch, volume, pbc,
+    )
+    assert legacy.shape == new.shape
+    torch.testing.assert_close(new, legacy, rtol=1e-10, atol=1e-12)
+
+
+def test_pbc_equivalence_two_graphs():
+    _set_dtype()
+    torch.manual_seed(1)
+
+    kspace_cutoff = 4.0
+    descriptor = _build_descriptor(
+        density_max_l=1, feature_max_l=1,
+        feature_widths=[1.0], kspace_cutoff=kspace_cutoff,
+    )
+
+    src_positions = torch.randn(8, 3) * 2.0
+    tgt_positions = torch.randn(5, 3) * 2.0 + 0.5
+    # 4 sources in graph 0, 4 in graph 1; 3 targets in graph 0, 2 in graph 1.
+    src_batch = torch.tensor([0, 0, 0, 0, 1, 1, 1, 1], dtype=torch.long)
+    tgt_batch = torch.tensor([0, 0, 0, 1, 1], dtype=torch.long)
+    src_feats = torch.randn(8, 4)
+
+    box = 8.0
+    cells = torch.eye(3).unsqueeze(0).expand(2, 3, 3).contiguous() * box
+    rcells = torch.inverse(cells)
+    volume = torch.det(cells)
+    pbc = torch.tensor([[True, True, True], [True, True, True]], dtype=torch.bool)
+
+    k_vectors, k_norm2, k_vector_batch, k0_mask = compute_k_vectors_flat(
+        kspace_cutoff, cells, rcells
+    )
+
+    legacy = _legacy_concat_and_slice(
+        descriptor, k_vectors, k_norm2, k_vector_batch, k0_mask,
+        src_positions, src_batch, src_feats, tgt_positions, tgt_batch, volume, pbc,
+    )
+    new = _new_source_target(
+        descriptor, k_vectors, k_norm2, k_vector_batch, k0_mask,
+        src_positions, src_batch, src_feats, tgt_positions, tgt_batch, volume, pbc,
+    )
+    torch.testing.assert_close(new, legacy, rtol=1e-10, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Non-PBC equivalence (molecule correction path)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("density_max_l,feature_max_l", [(0, 0), (0, 1), (1, 0), (1, 1)])
+def test_nonpbc_equivalence_single_graph(density_max_l, feature_max_l):
+    _set_dtype()
+    torch.manual_seed(2)
+
+    kspace_cutoff = 4.0
+    descriptor = _build_descriptor(
+        density_max_l=density_max_l,
+        feature_max_l=feature_max_l,
+        feature_widths=[0.8, 1.6],
+        kspace_cutoff=kspace_cutoff,
+    )
+
+    n_src, n_tgt = 5, 3
+    src_positions = torch.randn(n_src, 3)
+    tgt_positions = torch.randn(n_tgt, 3) + 0.3
+    src_batch = torch.zeros(n_src, dtype=torch.long)
+    tgt_batch = torch.zeros(n_tgt, dtype=torch.long)
+    m_dim = (density_max_l + 1) ** 2
+    src_feats = torch.randn(n_src, m_dim)
+
+    cell, rcell, volume, pbc = _make_nonpbc_geometry()
+    # k_vectors / k_norm2 for non-PBC: the realspace path doesn't use them, but
+    # we still need the tensors to have the right device/dtype shape.
+    k_vectors, k_norm2, k_vector_batch, k0_mask = compute_k_vectors_flat(
+        kspace_cutoff, cell, rcell
+    )
+
+    legacy = _legacy_concat_and_slice(
+        descriptor, k_vectors, k_norm2, k_vector_batch, k0_mask,
+        src_positions, src_batch, src_feats, tgt_positions, tgt_batch, volume, pbc,
+    )
+    new = _new_source_target(
+        descriptor, k_vectors, k_norm2, k_vector_batch, k0_mask,
+        src_positions, src_batch, src_feats, tgt_positions, tgt_batch, volume, pbc,
+    )
+    torch.testing.assert_close(new, legacy, rtol=1e-10, atol=1e-12)
+
+
+def test_nonpbc_force_pbc_evaluator_equivalence():
+    """Molecule + force_pbc_evaluator hits the molecule-correction branch in PBC mode."""
+    _set_dtype()
+    torch.manual_seed(3)
+
+    kspace_cutoff = 4.0
+    descriptor = _build_descriptor(
+        density_max_l=1, feature_max_l=1,
+        feature_widths=[1.0], kspace_cutoff=kspace_cutoff,
+    )
+
+    n_src, n_tgt = 5, 3
+    src_positions = torch.randn(n_src, 3)
+    tgt_positions = torch.randn(n_tgt, 3) + 0.5
+    src_batch = torch.zeros(n_src, dtype=torch.long)
+    tgt_batch = torch.zeros(n_tgt, dtype=torch.long)
+    src_feats = torch.randn(n_src, 4)
+
+    cell, rcell, volume, pbc = _make_nonpbc_geometry(box=20.0)
+    k_vectors, k_norm2, k_vector_batch, k0_mask = compute_k_vectors_flat(
+        kspace_cutoff, cell, rcell
+    )
+
+    legacy = _legacy_concat_and_slice(
+        descriptor, k_vectors, k_norm2, k_vector_batch, k0_mask,
+        src_positions, src_batch, src_feats, tgt_positions, tgt_batch, volume, pbc,
+        force_pbc_evaluator=True,
+    )
+    new = _new_source_target(
+        descriptor, k_vectors, k_norm2, k_vector_batch, k0_mask,
+        src_positions, src_batch, src_feats, tgt_positions, tgt_batch, volume, pbc,
+        force_pbc_evaluator=True,
+    )
+    torch.testing.assert_close(new, legacy, rtol=1e-10, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Gradient flow (autograd parity)
+# ---------------------------------------------------------------------------
+
+def test_pbc_gradients_match_concat_path():
+    _set_dtype()
+    torch.manual_seed(4)
+
+    kspace_cutoff = 4.0
+    descriptor = _build_descriptor(
+        density_max_l=0, feature_max_l=1,
+        feature_widths=[1.0], kspace_cutoff=kspace_cutoff,
+    )
+
+    n_src, n_tgt = 4, 3
+    src_positions_a = torch.randn(n_src, 3, requires_grad=True)
+    tgt_positions_a = torch.randn(n_tgt, 3, requires_grad=True)
+    src_batch = torch.zeros(n_src, dtype=torch.long)
+    tgt_batch = torch.zeros(n_tgt, dtype=torch.long)
+    src_feats = torch.randn(n_src, 1)
+
+    cell, rcell, volume, pbc = _make_pbc_geometry()
+    k_vectors, k_norm2, k_vector_batch, k0_mask = compute_k_vectors_flat(
+        kspace_cutoff, cell, rcell
+    )
+
+    legacy = _legacy_concat_and_slice(
+        descriptor, k_vectors, k_norm2, k_vector_batch, k0_mask,
+        src_positions_a, src_batch, src_feats, tgt_positions_a, tgt_batch, volume, pbc,
+    )
+    legacy.sum().backward()
+    grad_src_legacy = src_positions_a.grad.clone()
+    grad_tgt_legacy = tgt_positions_a.grad.clone()
+
+    src_positions_b = src_positions_a.detach().clone().requires_grad_(True)
+    tgt_positions_b = tgt_positions_a.detach().clone().requires_grad_(True)
+    new = _new_source_target(
+        descriptor, k_vectors, k_norm2, k_vector_batch, k0_mask,
+        src_positions_b, src_batch, src_feats, tgt_positions_b, tgt_batch, volume, pbc,
+    )
+    new.sum().backward()
+    torch.testing.assert_close(src_positions_b.grad, grad_src_legacy, rtol=1e-10, atol=1e-12)
+    torch.testing.assert_close(tgt_positions_b.grad, grad_tgt_legacy, rtol=1e-10, atol=1e-12)

--- a/tests/test_features_source_target.py
+++ b/tests/test_features_source_target.py
@@ -24,6 +24,13 @@ from graph_longrange.features import GTOElectrostaticFeatures
 from graph_longrange.kspace import compute_k_vectors_flat
 
 
+@pytest.fixture(autouse=True)
+def _restore_default_dtype():
+    default_dtype = torch.get_default_dtype()
+    yield
+    torch.set_default_dtype(default_dtype)
+
+
 # ---------------------------------------------------------------------------
 # Reference impl: legacy concat-and-slice path (mirrors _compute_mm_field_features)
 # ---------------------------------------------------------------------------
@@ -216,6 +223,69 @@ def test_pbc_equivalence_two_graphs():
         src_positions, src_batch, src_feats, tgt_positions, tgt_batch, volume, pbc,
     )
     torch.testing.assert_close(new, legacy, rtol=1e-10, atol=1e-12)
+
+
+def test_pbc_source_target_respects_independent_batches():
+    """A source from graph 1 must not contribute to graph 0 targets."""
+    _set_dtype()
+
+    kspace_cutoff = 4.0
+    descriptor = _build_descriptor(
+        density_max_l=0,
+        feature_max_l=1,
+        feature_widths=[1.0],
+        kspace_cutoff=kspace_cutoff,
+    )
+
+    src_positions = torch.tensor(
+        [
+            [0.1, 0.0, 0.0],
+            [0.2, 0.0, 0.0],
+        ]
+    )
+    tgt_positions = torch.tensor([[0.3, 0.0, 0.0]])
+    src_batch = torch.tensor([0, 1], dtype=torch.long)
+    tgt_batch = torch.tensor([0], dtype=torch.long)
+    src_feats = torch.tensor([[1.0], [1000.0]])
+
+    box = 8.0
+    cells = torch.eye(3).unsqueeze(0).expand(2, 3, 3).contiguous() * box
+    rcells = torch.inverse(cells)
+    volume = torch.det(cells)
+    pbc = torch.tensor([[True, True, True], [True, True, True]], dtype=torch.bool)
+    k_vectors, k_norm2, k_vector_batch, k0_mask = compute_k_vectors_flat(
+        kspace_cutoff, cells, rcells
+    )
+
+    both_sources = _new_source_target(
+        descriptor,
+        k_vectors,
+        k_norm2,
+        k_vector_batch,
+        k0_mask,
+        src_positions,
+        src_batch,
+        src_feats,
+        tgt_positions,
+        tgt_batch,
+        volume,
+        pbc,
+    )
+    graph0_only = _new_source_target(
+        descriptor,
+        k_vectors,
+        k_norm2,
+        k_vector_batch,
+        k0_mask,
+        src_positions[:1],
+        src_batch[:1],
+        src_feats[:1],
+        tgt_positions,
+        tgt_batch,
+        volume,
+        pbc,
+    )
+    torch.testing.assert_close(both_sources, graph0_only, rtol=1e-10, atol=1e-12)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Source-target electrostatics

`GTOElectrostaticFeatures` currently computes the field a set of smeared charges
makes at *itself* — the source set and the target set are the same. This adds the
asymmetric case: the field one set of charges (the sources) makes at a different
set of positions (the targets).

The motivating use is QM/MM electrostatic embedding, where classical MM point
charges polarise an ML region. Routing that through the existing symmetric path
means concatenating both sets into one system, computing everything, and slicing
out the cross terms — which also computes the source-source interactions that a
classical force field already owns, and pays for them.

### What's added

All of it sits alongside the existing methods rather than replacing them:

- `features.py` — `forward_source_target` and `precompute_geometry_source_target`
  on `GTOElectrostaticFeatures`, plus the real-space and PBC implementations
  behind them.
- `realspace_electrostatics.py` — `batch_bipartite_pairs` and
  `charges_features_from_bipartite_graph`, the bipartite analogues of the
  existing pair and graph builders, plus the `call_st_*` evaluation siblings.
- `slabs.py` — `slab_dipole_correction_node_fields_source_target`, so the 2D
  periodic correction applies in the asymmetric case too.

Gradients flow to both the source and target positions, so the back-reaction on
the sources is available and momentum is conserved.

### The one change to existing code

`DisplacedGTOExternalFieldBlock.forward` gains a `per_atom: bool = False`
argument. With the default it behaves exactly as before: the field is indexed
per graph and gauge-transformed to each node by `V_node = V_graph + E · r_node`.
With `per_atom=True` the field is taken as already evaluated at each atom, which
is what the source-target path produces, so no gauge transform is applied.

Two incidental cleanups in the same function: a local that was computed and never
used is dropped, and an in-place `+=` on the potential column becomes an
out-of-place add, which is the safer form when the tensor is part of an autograd
graph.

### Tests

`tests/test_features_source_target.py`, 12 tests, all passing. Every source-target
result is checked against the existing symmetric path applied to a concatenated
system, so the new code is validated against the code already in the library:

- PBC and non-PBC equivalence, parametrised over density and feature angular momenta
- two-graph batching, and batch isolation under PBC
- the `force_pbc_evaluator` path
- gradient agreement with the concatenated path

### Pre-existing failures

Three tests fail on this branch and fail identically on an untouched checkout of
`main`, so they are not from this change. All three look like the test suite
having drifted behind the library rather than anything numerical:

- `tests/test_fourier_gto.py` — does not import:
  `cannot import name 'FourierReconstructionBlock' from 'graph_longrange.kspace'`
- `tests/test_realspace_gto.py` — does not import:
  `No module named 'graph_longrange.realspace'` (the package now has
  `realspace_electrostatics` and `realspace_grid_integrals`)
- `test_gto_basis_reference.py::test_gto_basis_matches_old_reference` — passes
  `use_spline=True` and hits
  `NotImplementedError: splining of radial integral not supported`. The sibling
  test with `use_spline=False` passes.

Happy to fix these in a separate PR if they are just stale, though I did not want
to guess at the intended replacements.
